### PR TITLE
Ignore semver parsing errors

### DIFF
--- a/rubrical/comparison.py
+++ b/rubrical/comparison.py
@@ -13,18 +13,22 @@ def check_package(
             package.version[1:] if package.version.startswith("v") else package.version
         )
 
-        warn_signal = SemverComparison.GT.value != semver.compare(
-            package_semver,
-            package_requirement.warn[1:]
-            if package_requirement.warn.startswith("v")
-            else package_requirement.warn,
-        )
-        block_signal = SemverComparison.GT.value != semver.compare(
-            package_semver,
-            package_requirement.block[1:]
-            if package_requirement.block.startswith("v")
-            else package_requirement.block,
-        )
+        try:
+            warn_signal = SemverComparison.GT.value != semver.compare(
+                package_semver,
+                package_requirement.warn[1:]
+                if package_requirement.warn.startswith("v")
+                else package_requirement.warn,
+            )
+            block_signal = SemverComparison.GT.value != semver.compare(
+                package_semver,
+                package_requirement.block[1:]
+                if package_requirement.block.startswith("v")
+                else package_requirement.block,
+            )
+        except ValueError:
+            warn_signal = False
+            block_signal = False
     else:
         warn_signal = package_requirement.warn >= package.version
         block_signal = package_requirement.block >= package.version

--- a/tests/files/jsonnet/jsonnetfile.json
+++ b/tests/files/jsonnet/jsonnetfile.json
@@ -27,6 +27,15 @@
         }
       },
       "version": "v1.1.1"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "git@github.com:jsonnet-libs/argo-workflows-libsonAWESOME.git",
+          "subdir": ""
+        }
+      },
+      "version": "random-branch"
     }
   ],
   "legacyImports": true

--- a/tests/files/python/requirements.txt
+++ b/tests/files/python/requirements.txt
@@ -1,0 +1,10 @@
+###### Requirements without Version Specifiers ######
+nose
+nose-cov
+beautifulsoup4
+
+###### Requirements with Version Specifiers ######
+docopt == 0.6.1             # Version Matching. Must be version 0.6.1
+keyring >= 4.1.1            # Minimum version 4.1.1
+coverage != 3.5             # Version Exclusion. Anything except version 3.5
+Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.*

--- a/tests/unit/package_managers/test_jsonnet.py
+++ b/tests/unit/package_managers/test_jsonnet.py
@@ -11,6 +11,6 @@ def test_jsonnet():
     jsonnet.parse_package_manager_files()
 
     assert jsonnet.packages
-    assert len(jsonnet.packages["jsonnetfile.json"]) == 3
+    assert len(jsonnet.packages["jsonnetfile.json"]) == 4
     assert jsonnet.packages["jsonnetfile.json"][1].name == "xunleii/vector_jsonnet"
     assert jsonnet.packages["jsonnetfile.json"][1].version == "v0.1.2"

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -36,3 +36,13 @@ def test_dependency_actuallysemver():
     package = Package(**{"name": "dep1", "version": "v1.7.0"})
 
     assert PackageCheck.BLOCK == comparison.check_package(requirement, package)
+
+
+def test_dependency_branch():
+    requirement = PackageRequirement(
+        **{"name": "dep1", "type": "semver", "warn": "v1.11.1", "block": "v1.11.0"}
+    )
+
+    package = Package(**{"name": "dep1", "version": "some-random-branch"})
+
+    assert PackageCheck.OK == comparison.check_package(requirement, package)


### PR DESCRIPTION
If rubrical encounters semver parsing failures, fail safe (i.e. allow).  

Note: This needs to be refactored at some points to handle more complicated package dependencies.